### PR TITLE
Implement lookups by internal control name.

### DIFF
--- a/src/aadata.rs
+++ b/src/aadata.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code, non_snake_case, non_upper_case_globals, unused_variables)]
 
+use crate::abstract_::LookupByInternalControlName;
+use crate::abstract_::MatchesInternalControlName;
+use crate::aircraft::AircraftType;
 use crate::aircraft::AircraftType::*;
 use crate::aircraft::AircraftTypeClass;
 use crate::armor::ArmorType::*;
@@ -9,6 +12,8 @@ use crate::mission::MissionType::*;
 use crate::speed::MPHType::*;
 use crate::text::IDs::*;
 use crate::weapon::WeaponType::*;
+use strum::EnumCount;
+use strum::IntoEnumIterator;
 
 // A-10 attack plane
 const AttackPlane: AircraftTypeClass = AircraftTypeClass::new(
@@ -247,3 +252,37 @@ const CargoPlane: AircraftTypeClass = AircraftTypeClass::new(
     5,              // Rate of turn.
     MISSION_HUNT,   // Default mission for aircraft.
 );
+
+pub const BORROWS: [&AircraftTypeClass; AircraftType::COUNT] = [
+    &TransportHeli,
+    &AttackPlane,
+    &AttackHeli,
+    &CargoPlane,
+    &OrcaHeli,
+];
+
+impl LookupByInternalControlName for AircraftTypeClass {
+    type TypeEnum = AircraftType;
+
+    ///Converts an ASCII name into an aircraft type number.
+    /// This routine is used to convert an ASCII representation of an aircraft into the
+    /// matching aircraft type number. This is used by the scenario INI reader code.
+    ///
+    /// Was From_Name in C++ code.
+    fn lookup_type_enum_variant_by_internal_control_name(
+        internal_control_name: &str,
+    ) -> Option<Self::TypeEnum> {
+        for classid in Self::TypeEnum::iter() {
+            if BORROWS[classid as usize].matches_internal_control_name(internal_control_name) {
+                return Some(classid);
+            }
+        }
+        None
+    }
+}
+
+impl AircraftTypeClass {
+    pub const fn As_Reference(aircraft_type: AircraftType) -> &'static Self {
+        BORROWS[aircraft_type as usize]
+    }
+}

--- a/src/abstract_.rs
+++ b/src/abstract_.rs
@@ -1,12 +1,25 @@
 #![allow(dead_code, non_snake_case, non_upper_case_globals, unused_variables)]
 
-use crate::text::IDs;
-pub trait LookupByName {
-    type TypeEnum : Copy;
+use std::iter::zip;
 
-    fn lookup_type_enum_variant_by_name(
-        name: &str,
+use crate::text::IDs;
+
+pub trait MatchesInternalControlName {
+    fn matches_internal_control_name(&self, other_internal_control_name: &str) -> bool;
+}
+
+pub trait LookupByInternalControlName: MatchesInternalControlName {
+    type TypeEnum: Copy;
+
+    fn lookup_type_enum_variant_by_internal_control_name(
+        internal_control_name: &str,
     ) -> Option<Self::TypeEnum>;
+}
+
+pub trait LookupByName {
+    type TypeEnum: Copy;
+
+    fn lookup_type_enum_variant_by_name(name: &str) -> Option<Self::TypeEnum>;
 }
 
 /// This is the abstract type class. It holds information common to all
@@ -18,13 +31,24 @@ pub struct AbstractTypeClass {
     /// not change regardless of language specified. This is the name
     /// used in scenario control files and for other text based unique
     /// identification purposes.
-    IniName: [char; 9],
+    pub IniName: [char; 9],
 
     /// The translated (language specific) text name number of this object.
     /// This number is used to fetch the object's name from the language
     /// text file. Whenever the name of the object needs to be displayed,
     /// this is used to determine the text string.
     Name: Option<IDs>,
+}
+
+impl MatchesInternalControlName for AbstractTypeClass {
+    fn matches_internal_control_name(&self, other_internal_control_name: &str) -> bool {
+        for (lhs, rhs) in zip(self.IniName.iter(), other_internal_control_name.bytes()) {
+            if *lhs != (rhs as char) {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 impl AbstractTypeClass {

--- a/src/aircraft.rs
+++ b/src/aircraft.rs
@@ -6,13 +6,17 @@
     unused_variables
 )]
 
+use strum_macros::{EnumCount, EnumIter};
+
 use crate::{
-    armor::ArmorType, building::STRUCTF, ini::IniName, mission::MissionType, speed::MPHType,
-    techno::TechnoTypeClass, text::IDs, weapon::WeaponType,
+    abstract_::MatchesInternalControlName, armor::ArmorType, building::STRUCTF, ini::IniName,
+    mission::MissionType, speed::MPHType, techno::TechnoTypeClass, text::IDs, weapon::WeaponType,
 };
 
 ///	The variuos aircraft types are enumerated here. These include helicopters
 ///	as well as traditional aircraft.
+#[derive(Clone, Copy, EnumCount, EnumIter)]
+#[repr(u8)]
 pub enum AircraftType {
     AIRCRAFT_TRANSPORT,  // Transport helicopter.
     AIRCRAFT_A10,        // Ground attack plane.
@@ -137,5 +141,11 @@ impl AircraftTypeClass {
             ROT: rot,
             Mission: deforder,
         }
+    }
+}
+impl MatchesInternalControlName for AircraftTypeClass {
+    fn matches_internal_control_name(&self, other_internal_control_name: &str) -> bool {
+        self.techno_type_class
+            .matches_internal_control_name(other_internal_control_name)
     }
 }

--- a/src/hdata.rs
+++ b/src/hdata.rs
@@ -1,10 +1,15 @@
 #![allow(dead_code, non_snake_case, non_upper_case_globals, unused_variables)]
 
+use crate::abstract_::LookupByInternalControlName;
+use crate::abstract_::MatchesInternalControlName;
 use crate::color::*;
 use crate::house::HouseTypeClass;
+use crate::house::HousesType;
 use crate::house::HousesType::*;
 use crate::player::PlayerColorType::*;
 use crate::text::IDs::*;
+use strum::EnumCount;
+use strum::IntoEnumIterator;
 
 /// These are the colors used to identify the various owners.
 
@@ -144,3 +149,31 @@ const HouseMulti6: HouseTypeClass = HouseTypeClass::new(
     RemapRed,             // Default remap table.
     'M',                  // VOICE:		Voice prefix character.
 );
+
+const BORROWS: [&HouseTypeClass; HousesType::COUNT] = [
+    &HouseGood,
+    &HouseBad,
+    &HouseCivilian,
+    &HouseJP,
+    &HouseMulti1,
+    &HouseMulti2,
+    &HouseMulti3,
+    &HouseMulti4,
+    &HouseMulti5,
+    &HouseMulti6,
+];
+
+impl LookupByInternalControlName for HouseTypeClass {
+    type TypeEnum = HousesType;
+
+    fn lookup_type_enum_variant_by_internal_control_name(
+        internal_control_name: &str,
+    ) -> Option<Self::TypeEnum> {
+        for classid in Self::TypeEnum::iter() {
+            if BORROWS[classid as usize].matches_internal_control_name(internal_control_name) {
+                return Some(classid);
+            }
+        }
+        None
+    }
+}

--- a/src/house.rs
+++ b/src/house.rs
@@ -7,11 +7,13 @@
 )]
 
 use bitflags::bitflags;
+use strum_macros::{EnumCount, EnumIter};
 
-use crate::{player::PlayerColorType, text::IDs};
+use crate::{abstract_::MatchesInternalControlName, player::PlayerColorType, text::IDs};
 
 ///	The houses that can be played are listed here. Each has their own
 ///	personality and strengths.
+#[derive(Copy, Clone, EnumCount, EnumIter)]
 #[repr(u8)]
 pub enum HousesType {
     //HOUSE_NONE=-1,
@@ -88,6 +90,12 @@ pub struct HouseTypeClass {
     /// serves a similar purpose as the "Suffix" element, but is only one
     /// character long.
     Prefix: char,
+}
+
+impl MatchesInternalControlName for HouseTypeClass {
+    fn matches_internal_control_name(&self, other_internal_control_name: &str) -> bool {
+        self.IniName == other_internal_control_name
+    }
 }
 
 impl HouseTypeClass {

--- a/src/idata.rs
+++ b/src/idata.rs
@@ -1,8 +1,12 @@
 #![allow(dead_code, non_snake_case, non_upper_case_globals, unused_variables)]
-use strum::EnumCount;
+use strum::{EnumCount, IntoEnumIterator};
 
+use crate::abstract_::{LookupByInternalControlName, MatchesInternalControlName};
 use crate::house::HOUSEF;
-use crate::infantry::{DoInfoStruct, DoType, InfantryType::*};
+use crate::infantry::{
+    DoInfoStruct, DoType,
+    InfantryType::{self, *},
+};
 use crate::speed::MPHType::*;
 use crate::text::IDs::*;
 use crate::weapon::WeaponType::*;
@@ -1538,3 +1542,38 @@ const DrChan: InfantryTypeClass = InfantryTypeClass::new(
     None,
     MPH_SLOW_ISH,
 );
+
+/// This is the array of classes to the static data associated with each
+///	infantry type.
+const BORROWS: [&InfantryTypeClass; InfantryType::COUNT] = [
+    &E1, &E2, &E3, &E4, &E5, //	&E6,
+    &E7, &Commando, &C1, &C2, &C3, &C4, &C5, &C6, &C7, &C8, &C9, &C10, &Moebius, &Delphi, &DrChan,
+];
+
+impl LookupByInternalControlName for InfantryTypeClass {
+    type TypeEnum = InfantryType;
+
+    /// Converts an ASCII name into an infantry type enum variant/number.
+    /// This routine is used to convert the infantry ASCII name as specified into an infantry
+    /// type number. This is called from the INI reader routine in the process if creating the
+    /// infantry objects needed for the scenario.
+    ///
+    /// Returns with the infantry type number that corresponds to the infantry ASCII name
+    /// specified. If no match could be found, then None is returned.
+    ///
+    /// Was From_Name in C++ code.
+    fn lookup_type_enum_variant_by_internal_control_name(name: &str) -> Option<Self::TypeEnum> {
+        for classid in Self::TypeEnum::iter() {
+            if BORROWS[classid as usize].matches_internal_control_name(name) {
+                return Some(classid);
+            }
+        }
+        None
+    }
+}
+
+impl InfantryTypeClass {
+    pub const fn As_Reference(infantry_type: InfantryType) -> &'static Self {
+        BORROWS[infantry_type as usize]
+    }
+}

--- a/src/infantry.rs
+++ b/src/infantry.rs
@@ -9,16 +9,18 @@
 use std::ops::Index;
 
 use crate::{
+    abstract_::MatchesInternalControlName,
     building::{self},
     techno::TechnoTypeClass,
 };
 use strum::EnumCount;
-use strum_macros::EnumCount;
+use strum_macros::{EnumCount, EnumIter};
 
 use crate::{speed::MPHType, text::IDs, weapon::WeaponType};
 
 ///	This specifies the infantry in the game. The "E" designation is
 ///	similar to the army classification of enlisted soldiers.
+#[derive(Clone, Copy, Debug, EnumCount, EnumIter)]
 pub enum InfantryType {
     //INFANTRY_NONE=-1,
     INFANTRY_E1,    // Mini-gun armed.
@@ -152,6 +154,12 @@ impl DoInfoStruct {
             Count: count,
             Jump: jump,
         }
+    }
+}
+
+impl MatchesInternalControlName for InfantryTypeClass {
+    fn matches_internal_control_name(&self, name: &str) -> bool {
+        self.techno_type_class.matches_internal_control_name(name)
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_upper_case_globals, unused_variables)]
 
-use crate::{abstract_::AbstractTypeClass, armor::ArmorType, text::IDs};
+use crate::{abstract_::{AbstractTypeClass, MatchesInternalControlName}, armor::ArmorType, text::IDs};
 
 /// This the the common base class of game objects. Since these values
 /// represent the unchanging object TYPES, this data is initialized at game
@@ -58,6 +58,12 @@ pub struct ObjectTypeClass {
 
     /// This points to the radar imagery for this object.
     RadarIcon: [u8; 0],
+}
+
+impl MatchesInternalControlName for ObjectTypeClass {
+    fn matches_internal_control_name(&self, other_internal_control_name: &str) -> bool {
+        self.abstract_type_class.matches_internal_control_name(other_internal_control_name)
+    }
 }
 
 impl ObjectTypeClass {

--- a/src/techno.rs
+++ b/src/techno.rs
@@ -1,12 +1,7 @@
 #![allow(dead_code, non_snake_case, non_upper_case_globals, unused_variables)]
 
 use crate::{
-    armor::ArmorType,
-    building::STRUCTF,
-    object::ObjectTypeClass,
-    speed::MPHType,
-    text::IDs,
-    weapon::{WeaponType, Weapons},
+    abstract_::MatchesInternalControlName, armor::ArmorType, building::STRUCTF, object::ObjectTypeClass, speed::MPHType, text::IDs, weapon::{WeaponType, Weapons}
 };
 
 /// This class is the common data for all objects that can be owned, produced,
@@ -108,6 +103,12 @@ pub struct TechnoTypeClass {
     /// These are the weapons that this techno object is armed with.
     Primary: Option<WeaponType>,
     Secondary: Option<WeaponType>,
+}
+
+impl MatchesInternalControlName for TechnoTypeClass {
+    fn matches_internal_control_name(&self, name: &str) -> bool {
+        self.object_type_class.matches_internal_control_name(name)
+    }
 }
 
 impl TechnoTypeClass {

--- a/src/udata.rs
+++ b/src/udata.rs
@@ -5,6 +5,8 @@
     non_upper_case_globals,
     unused_variables
 )]
+use crate::abstract_::LookupByInternalControlName;
+use crate::abstract_::MatchesInternalControlName;
 use crate::animation::AnimType::*;
 use crate::armor::ArmorType::*;
 use crate::building::STRUCTF;
@@ -13,10 +15,13 @@ use crate::mission::MissionType::*;
 use crate::speed::MPHType::*;
 use crate::speed::SpeedType::*;
 use crate::text::IDs::*;
+use crate::unit::UnitType;
 use crate::unit::UnitType::*;
 use crate::unit::UnitTypeClass;
 use crate::weapon::WeaponType::*;
 use crate::ADVANCED;
+use strum::EnumCount;
+use strum::IntoEnumIterator;
 
 // Visceroid
 const UnitVisceroid: UnitTypeClass = UnitTypeClass::new(
@@ -1299,3 +1304,54 @@ const UnitSteg: UnitTypeClass = UnitTypeClass::new(
     0,             // Turret center offset along body centerline.
     MISSION_GUARD, // ORDERS:		Default order to give new unit.
 );
+
+/// This is the array of pointers to the static data associated with each
+/// vehicle type.
+const BORROWS: [&UnitTypeClass; UnitType::COUNT] = [
+    &UnitHTank,     //	UNIT_HTANK
+    &UnitMTank,     //	UNIT_MTANK
+    &UnitLTank,     //	UNIT_LTANK
+    &UnitSTank,     //	UNIT_STANK
+    &UnitFTank,     //	UNIT_FTANK
+    &UnitVisceroid, // UNIT_VICE
+    &UnitAPC,       //	UNIT_APC
+    &UnitMLRS,      //	UNIT_MLRS
+    &UnitJeep,      //	UNIT_JEEP
+    &UnitBuggy,     //	UNIT_BUGGY
+    &UnitHarvester, //	UNIT_HARVESTER
+    &UnitArty,      //	UNIT_ARTY
+    &UnitSAM,       //	UNIT_MSAM
+    &UnitHover,     //	UNIT_HOVER
+    &UnitMHQ,       //	UNIT_MHQ
+    &UnitGunBoat,   //	UNIT_GUNBOAT
+    &UnitMCV,       // UNIT_MCV
+    &UnitBike,      // UNIT_BIKE
+    &UnitTric,      // UNIT_TRIC
+    &UnitTrex,      // UNIT_TREX
+    &UnitRapt,      // UNIT_RAPT
+    &UnitSteg,      // UNIT_STEG
+];
+
+impl LookupByInternalControlName for UnitTypeClass {
+    type TypeEnum = UnitType;
+
+    /// Fetch class type from specified name.
+    /// This routine converts an ASCII representation of a unit class and
+    /// converts it into a real unit class number.
+    ///
+    /// Was From_Name in C++ code.
+    fn lookup_type_enum_variant_by_internal_control_name(name: &str) -> Option<Self::TypeEnum> {
+        for classid in Self::TypeEnum::iter() {
+            if BORROWS[classid as usize].matches_internal_control_name(name) {
+                return Some(classid);
+            }
+        }
+        None
+    }
+}
+
+impl UnitTypeClass {
+    pub const fn As_Reference(unit_type: UnitType) -> &'static Self {
+        BORROWS[unit_type as usize]
+    }
+}

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -5,7 +5,10 @@
     non_upper_case_globals,
     unused_variables
 )]
+use strum_macros::{EnumCount, EnumIter};
+
 use crate::{
+    abstract_::MatchesInternalControlName,
     animation::AnimType,
     armor::ArmorType,
     building,
@@ -20,6 +23,7 @@ use crate::{
 
 /// The game units are enumerated here. These include not only traditional
 /// vehicles, but also hovercraft and gunboats.
+#[derive(Clone, Copy, EnumCount, EnumIter)]
 #[repr(u8)]
 pub enum UnitType {
     //UNIT_NONE=-1,
@@ -258,5 +262,12 @@ impl UnitTypeClass {
             Type: type_,
             MaxSize: 0,
         }
+    }
+}
+
+impl MatchesInternalControlName for UnitTypeClass {
+    fn matches_internal_control_name(&self, other_internal_control_name: &str) -> bool {
+        self.techno_type_class
+            .matches_internal_control_name(other_internal_control_name)
     }
 }


### PR DESCRIPTION
Port lists of compiletime definitions from C++ to Rust. In C++ these were often named Pointers - renamed to Rust idiom. BORROWS.

Introduced new trait LookupByInternalControlName.
Actual matching of names is delegated down the chain to AbstractTypeClass.