### PR TITLE
Utilize regex to port TeamTypeClass::Fill_in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,9 +7,19 @@ name = "CnC_Tiberian_Dawn"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "regex",
  "rust-ini",
  "strum",
  "strum_macros",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -89,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +137,35 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rust-ini"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ proc-macro = true
 
 [dependencies]
 bitflags = "2.9.0"
+regex = "1.11.1"
 rust-ini = "0.21.1"
 strum = "0.27.1"
 strum_macros = "0.27.1"

--- a/src/abstract_.rs
+++ b/src/abstract_.rs
@@ -52,9 +52,20 @@ impl MatchesInternalControlName for AbstractTypeClass {
 }
 
 impl AbstractTypeClass {
-    pub const fn new(name: Option<IDs>, ini: &str) -> Self {
+    pub const fn new(name: Option<IDs>, ini_name: &str) -> Self {
+        Self {
+            Name: name,
+            IniName: Self::build_ini_name(ini_name),
+        }
+    }
+
+    pub fn Set_Name(&mut self, buf: &str) {
+        self.IniName = Self::build_ini_name(buf);
+    }
+
+    const fn build_ini_name(buf: &str) -> [char; 9] {
         let mut ini_name = ['\0'; 9];
-        let ini_bytes = ini.as_bytes();
+        let ini_bytes = buf.as_bytes();
         let len = if ini_bytes.len() < 9 {
             ini_bytes.len()
         } else {
@@ -66,10 +77,6 @@ impl AbstractTypeClass {
             ini_name[i] = ini_bytes[i] as char;
             i += 1;
         }
-
-        Self {
-            Name: name,
-            IniName: ini_name,
-        }
+        ini_name
     }
 }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,16 +1,45 @@
 #![allow(dead_code, non_snake_case, non_upper_case_globals, unused_variables)]
 
+use std::ops::Index;
+
 pub struct TFixedIHeapClass<T>(Vec<T>);
 
 pub enum InsertError {
     ReachedCapacity,
 }
 
-impl<T> TFixedIHeapClass<T> {
+impl<T> Index<usize> for TFixedIHeapClass<T> {
+    type Output = <Vec<T> as Index<usize>>::Output;
+    fn index(&self, index: usize) -> &Self::Output {
+        self.0.index(index)
+    }
+}
+
+impl<T: Default> TFixedIHeapClass<T> {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             0: Vec::with_capacity(capacity),
         }
+    }
+
+    pub fn resize_with_default(&mut self, new_len: usize) -> Result<(), InsertError> {
+        if new_len > self.0.capacity() {
+            return Err(InsertError::ReachedCapacity);
+        }
+        self.0.resize_with(new_len, Default::default);
+        Ok(())
+    }
+
+    pub fn split_at(&self, mid: usize) -> (&[T], &[T]) {
+        self.0.split_at(mid)
+    }
+
+    pub fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]) {
+        self.0.split_at_mut(mid)
+    }
+
+    pub fn position_of(&self, t: &T) -> Option<usize> {
+        self.0.iter().position(|v| std::ptr::eq(v, t))
     }
 
     pub fn try_push(&mut self, value: T) -> Result<(), InsertError> {

--- a/src/house.rs
+++ b/src/house.rs
@@ -13,7 +13,7 @@ use crate::{abstract_::MatchesInternalControlName, player::PlayerColorType, text
 
 ///	The houses that can be played are listed here. Each has their own
 ///	personality and strengths.
-#[derive(Copy, Clone, EnumCount, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumCount, EnumIter, PartialEq)]
 #[repr(u8)]
 pub enum HousesType {
     //HOUSE_NONE=-1,

--- a/src/team.rs
+++ b/src/team.rs
@@ -5,15 +5,19 @@
     non_upper_case_globals,
     unused_variables
 )]
+
+use crate::abstract_::LookupByName;
+use regex::{Captures, Regex};
+use std::{num::ParseIntError, sync::LazyLock};
 use strum_macros::{EnumCount, EnumIter};
 
 use crate::{
-    abstract_::AbstractTypeClass,
+    abstract_::{AbstractTypeClass, LookupByInternalControlName},
     aircraft::AircraftTypeClass,
-    heap::{InsertError, TFixedIHeapClass},
-    house::HousesType,
+    house::{HouseTypeClass, HousesType},
     infantry::InfantryTypeClass,
     ini::IniName,
+    tmdata::TeamMissionNames,
     unit::UnitTypeClass,
 };
 
@@ -39,7 +43,7 @@ pub enum TeamMissionType {
 }
 
 /// This structure contains one team mission value & its argument.
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct TeamMissionStruct {
     Mission: Option<TeamMissionType>,
     Argument: i32,
@@ -47,14 +51,32 @@ pub struct TeamMissionStruct {
 
 enum TechnoTypeClasses {
     None,
-    Aircraft(AircraftTypeClass),
-    Infantry(InfantryTypeClass),
-    Unit(UnitTypeClass),
+    Aircraft(&'static AircraftTypeClass),
+    Infantry(&'static InfantryTypeClass),
+    Unit(&'static UnitTypeClass),
 }
 
 impl Default for TechnoTypeClasses {
     fn default() -> Self {
         Self::None
+    }
+}
+
+impl From<&'static AircraftTypeClass> for TechnoTypeClasses {
+    fn from(value: &'static AircraftTypeClass) -> Self {
+        Self::Aircraft(value)
+    }
+}
+
+impl From<&'static InfantryTypeClass> for TechnoTypeClasses {
+    fn from(value: &'static InfantryTypeClass) -> Self {
+        Self::Infantry(value)
+    }
+}
+
+impl From<&'static UnitTypeClass> for TechnoTypeClasses {
+    fn from(value: &'static UnitTypeClass) -> Self {
+        Self::Unit(value)
     }
 }
 
@@ -119,7 +141,7 @@ pub struct TeamTypeClass {
     House: Option<HousesType>,
 
     /// The mission list for this team
-    MissionCount: i32,
+    MissionCount: u8,
     MissionList: [TeamMissionStruct; MAX_TEAM_MISSIONS],
 
     /// Number of different classes in the team
@@ -144,17 +166,234 @@ pub enum NewError {
 
 impl TeamTypeClass {
     /// Creates a new instance of TeamTypeClass in Scenario
-    pub fn try_new(
-        team_types: &mut TFixedIHeapClass<TeamTypeClass>,
-    ) -> Result<&mut Self, NewError> {
-        team_types
-            .try_push(TeamTypeClass {
-                IsActive: true,
+    ///
+    /// Was new in C++ code.
+    pub fn new(buf: &mut TeamTypeClass) -> &mut Self {
+        *buf = Self {
+            IsActive: true,
+            ..Default::default()
+        };
+        buf
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FillError {
+    ParseIntError(ParseIntError),
+}
+
+static INI_LINE_PARSER: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?<house>\w+),(?<roundabout>\d+),(?<learning>\d+),(?<suicide>\d+),(?<autocreate>\d+),(?<mercenary>\d+),(?<recruit>\d+),(?<max>\d+),(?<init>\d+),(?<fear>\d+),(?<classcount>\d+),(.*)").unwrap()
+});
+
+impl TeamTypeClass {
+    fn parse_bool(s: &str) -> Result<bool, FillError> {
+        Ok(Self::i32_to_bool(Self::parse_i32(s)?))
+    }
+
+    fn parse_i32(s: &str) -> Result<i32, FillError> {
+        s.parse::<i32>()
+            .map_err(|err| FillError::ParseIntError(err))
+    }
+
+    fn parse_u8(s: &str) -> Result<u8, FillError> {
+        s.parse::<u8>().map_err(|err| FillError::ParseIntError(err))
+    }
+
+    fn parse_bool_group(captures: &Captures, i: usize) -> Result<bool, FillError> {
+        Self::parse_bool(captures.get(i).unwrap().as_str())
+    }
+
+    fn parse_i32_group(captures: &Captures, i: usize) -> Result<i32, FillError> {
+        Self::parse_i32(captures.get(i).unwrap().as_str())
+    }
+
+    fn parse_u8_group(captures: &Captures, i: usize) -> Result<u8, FillError> {
+        Self::parse_u8(captures.get(i).unwrap().as_str())
+    }
+
+    fn i32_to_bool(v: i32) -> bool {
+        v != 0
+    }
+
+    /// fills in trigger from the given INI entry
+    /// This routine fills in the given teamtype with the given name, and values from
+    /// the given INI entry.
+    /// (This routine is used by the scenario editor, to import teams from the MASTER.INI file.)
+    ///
+    /// Parameters:
+    /// * name: mnemonic for the desired trigger
+    /// * entry: comma separated value to parse. Contains
+    ///   Housename,Roundabout,Learning,Suicide,Spy,Mercenary,
+    ///   RecruitPriority,MaxAllowed,InitNum,Fear,
+    ///   ClassCount,Class:Num,Class:Num,...,
+    ///   MissionCount,Mission:Arg,Mission:Arg,Mission:Arg,...
+    fn Fill_In(&mut self, name: &str, entry: &str) -> Result<(), FillError> {
+        let captured = INI_LINE_PARSER
+            .captures(entry)
+            .expect("entry should contain proper values");
+
+        // ------------------------------ Set its name ------------------------------
+        self.abstract_type_class.Set_Name(name);
+
+        // ---------------------------- 1st token: House ----------------------------
+        self.House = HouseTypeClass::lookup_type_enum_variant_by_internal_control_name(
+            captured
+                .get(1)
+                .expect("House should always be specified")
+                .as_str(),
+        );
+
+        // -------------------------- 2nd token: RoundAbout -------------------------
+        self.IsRoundAbout = Self::parse_bool_group(&captured, 2)?;
+
+        // --------------------------- 3rd token: Learning --------------------------
+        self.IsLearning = Self::parse_bool_group(&captured, 3)?;
+
+        // --------------------------- 4th token: Suicide ---------------------------
+        self.IsSuicide = Self::parse_bool_group(&captured, 4)?;
+
+        // ----------------------------- 5th token: Spy -----------------------------
+        self.IsAutocreate = Self::parse_bool_group(&captured, 5)?;
+
+        // -------------------------- 6th token: Mercenary --------------------------
+        self.IsMercenary = Self::parse_bool_group(&captured, 6)?;
+
+        // ----------------------- 7th token: RecruitPriority -----------------------
+        self.RecruitPriority = Self::parse_i32_group(&captured, 7)?;
+
+        // -------------------------- 8th token: MaxAllowed -------------------------
+        self.MaxAllowed = Self::parse_u8_group(&captured, 8)?;
+
+        // --------------------------- 9th token: InitNum ---------------------------
+        self.InitNum = Self::parse_u8_group(&captured, 9)?;
+
+        // ------------------------- 10th token: Fear level -------------------------
+        self.Fear = Self::parse_u8_group(&captured, 10)?;
+
+        //------------------------ 11th token: Class count -------------------------
+        let num_classes = Self::parse_u8_group(&captured, 11)?;
+
+        let rest = captured.get(12).unwrap().as_str();
+
+        let it = rest.split(',');
+
+        // -------------- Loop through entries, setting class borrows & num -------------
+        self.ClassCount = 0;
+        for s in it.clone().take(num_classes.into()) {
+            let mut it = s.splitn(2, ':');
+            let p1 = it.next().unwrap();
+            let p2 = it.next().unwrap();
+
+            // ------------------- See if this is an infantry name -------------------
+            match InfantryTypeClass::lookup_type_enum_variant_by_internal_control_name(p1) {
+                None => (),
+                Some(i_id) => {
+                    // --------------- If the name was resolved, add this class --------------
+                    self.register_techno_class(p2, InfantryTypeClass::As_Reference(i_id).into())
+                        .map_err(|err| FillError::ParseIntError(err))?;
+                }
+            }
+
+            // ---------------------- See if this is a unit name ---------------------
+            match UnitTypeClass::lookup_type_enum_variant_by_internal_control_name(p1) {
+                None => (),
+                Some(u_id) => {
+                    // --------------- If the name was resolved, add this class --------------
+                    self.register_techno_class(p2, UnitTypeClass::As_Reference(u_id).into())
+                        .map_err(|err| FillError::ParseIntError(err))?;
+                }
+            }
+
+            // ------------------- See if this is an aircraft name -------------------
+            match AircraftTypeClass::lookup_type_enum_variant_by_internal_control_name(p1) {
+                None => (),
+                Some(a_id) => {
+                    // --------------- If the name was resolved, add this class --------------
+                    self.register_techno_class(p2, AircraftTypeClass::As_Reference(a_id).into())
+                        .map_err(|err| FillError::ParseIntError(err))?;
+                }
+            }
+        }
+
+        let mut rest_it = it.skip(num_classes.into());
+
+        self.MissionCount = Self::parse_u8(rest_it.next().unwrap())?;
+
+        // ----------------------- next token: Mission count ------------------------
+        for (i, s) in rest_it.clone().take(self.MissionCount.into()).enumerate() {
+            let mut it = s.splitn(2, ':');
+            let p1 = it.next().unwrap();
+            let p2 = it.next().unwrap();
+            let mission = &mut self.MissionList[i];
+            mission.Mission = TeamMissionNames::lookup_type_enum_variant_by_name(p1);
+            mission.Argument = p2.parse().map_err(|err| FillError::ParseIntError(err))?;
+        }
+
+        let mut opt_it = rest_it.skip(self.MissionCount.into());
+        match opt_it.next() {
+            None => return Ok(()),
+            Some(reinforcable) => {
+                self.IsReinforcable = Self::parse_bool(reinforcable)?;
+            }
+        }
+        match opt_it.next() {
+            None => return Ok(()),
+            Some(prebuilt) => {
+                self.IsPrebuilt = Self::parse_bool(prebuilt)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn register_techno_class(
+        &mut self,
+        p2: &str,
+        techno_type_classable: TechnoTypeClasses,
+    ) -> Result<(), ParseIntError> {
+        self.Class[self.ClassCount as usize] = techno_type_classable;
+        self.DesiredNum[self.ClassCount as usize] = p2.parse()?;
+        self.ClassCount += 1;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fill_in_works() {
+        let mut buf: [TeamTypeClass; 1] = [Default::default(); 1];
+        let ttc = &mut buf[0];
+        TeamTypeClass::new(ttc);
+        let result = ttc.Fill_In(
+            "NOD7",
+            "BadGuy,1,0,0,0,0,15,0,0,0,2,E1:2,LTNK:1,1,Attack Units:40,0,0",
+        );
+        assert_eq!(result, Ok(()));
+        assert_eq!(ttc.House, Some(HousesType::HOUSE_BAD));
+        assert_eq!(ttc.IsActive, true);
+        assert_eq!(ttc.IsRoundAbout, true);
+        assert_eq!(ttc.IsLearning, false);
+        assert_eq!(ttc.IsSuicide, false);
+        assert_eq!(ttc.IsAutocreate, false);
+        assert_eq!(ttc.IsMercenary, false);
+        assert_eq!(ttc.RecruitPriority, 15);
+        assert_eq!(ttc.MaxAllowed, 0);
+        assert_eq!(ttc.ClassCount, 2);
+        assert_eq!(ttc.MissionCount, 1);
+        assert_eq!(ttc.MissionList, {
+            let mut ms = [TeamMissionStruct {
                 ..Default::default()
-            })
-            .map_err(|err| match err {
-                InsertError::ReachedCapacity => NewError::NewFailedDueToCapacity,
-            })?;
-        Ok(team_types.last_mut().unwrap())
+            }; MAX_TEAM_MISSIONS];
+            ms[0] = TeamMissionStruct {
+                Mission: Some(TeamMissionType::TMISSION_ATTACKUNITS),
+                Argument: 40,
+            };
+            ms
+        });
+        assert_eq!(ttc.IsReinforcable, false);
+        assert_eq!(ttc.IsPrebuilt, false);
     }
 }


### PR DESCRIPTION
Needed to add and utilize split_at_mut to get mutable borrows inside of arrays to compile.
In turn split_at_mut has been added to TFixedIHeapClassHeap.