### PR TITLE
Implement reading ini for TeamTypeClass.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,5 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Create Test Data
+        env:
+          SCG62EA_INI: ${{ secrets.SCG62EA_INI }}
+        run: |
+          mkdir -p tests/testdata && echo "$SCG62EA_INI" > "${{ github.workspace }}/tests/testdata/SCG62EA.INI"
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+SCG62EA.INI

--- a/src/base.rs
+++ b/src/base.rs
@@ -8,6 +8,7 @@
 
 use crate::ini::IniName;
 
+#[derive(Default)]
 pub struct BaseClass {}
 
 impl IniName for BaseClass {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -4,8 +4,11 @@ use std::ops::Index;
 
 pub struct TFixedIHeapClass<T>(Vec<T>);
 
+#[derive(Debug, PartialEq)]
 pub enum InsertError {
-    ReachedCapacity,
+    /// First value is requested
+    /// Second value is capacity
+    ReachedCapacity(usize, usize),
 }
 
 impl<T> Index<usize> for TFixedIHeapClass<T> {
@@ -24,7 +27,7 @@ impl<T: Default> TFixedIHeapClass<T> {
 
     pub fn resize_with_default(&mut self, new_len: usize) -> Result<(), InsertError> {
         if new_len > self.0.capacity() {
-            return Err(InsertError::ReachedCapacity);
+            return Err(InsertError::ReachedCapacity(new_len, self.0.capacity()));
         }
         self.0.resize_with(new_len, Default::default);
         Ok(())
@@ -44,7 +47,10 @@ impl<T: Default> TFixedIHeapClass<T> {
 
     pub fn try_push(&mut self, value: T) -> Result<(), InsertError> {
         if self.len() == self.0.capacity() {
-            return Err(InsertError::ReachedCapacity);
+            return Err(InsertError::ReachedCapacity(
+                self.len() + 1,
+                self.0.capacity(),
+            ));
         }
 
         self.0.push(value);
@@ -58,7 +64,10 @@ impl<T: Default> TFixedIHeapClass<T> {
     /// Was Alloc(void) in C++ code
     pub fn insert(&mut self, index: usize, element: T) -> Result<(), InsertError> {
         if self.len() == self.0.capacity() {
-            return Err(InsertError::ReachedCapacity);
+            return Err(InsertError::ReachedCapacity(
+                self.len() + 1,
+                self.0.capacity(),
+            ));
         }
         self.0.insert(index, element);
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ mod unit;
 mod weapon;
 
 mod mdata_test;
+mod team_test;
 mod tmdata_test;
 
 const ADVANCED: bool = false;

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -4,6 +4,8 @@ use crate::{
     base::BaseClass, heap::TFixedIHeapClass, movie::Movies, team::TeamTypeClass, theme::ThemeClass,
 };
 
+const TEAMTYPE_MAX: usize = 40;
+
 pub struct Scenario {
     movies: Movies,
     /// This is the list of BuildingTypes that define the AI's base.
@@ -12,4 +14,15 @@ pub struct Scenario {
     /// Used to be ScenarioCRC in C++ code
     //CRC: crc::Crc<u64>,
     pub TeamTypes: TFixedIHeapClass<TeamTypeClass>,
+}
+
+impl Scenario {
+    pub fn new() -> Self {
+        Self {
+            TeamTypes: TFixedIHeapClass::with_capacity(TEAMTYPE_MAX),
+            base: Default::default(),
+            movies: Default::default(),
+            theme: Default::default(),
+        }
+    }
 }

--- a/src/team_test.rs
+++ b/src/team_test.rs
@@ -1,0 +1,32 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        heap::{InsertError, TFixedIHeapClass},
+        team::{FromIniError, ReadTeamEntriesError, TeamTypeClass},
+    };
+    use ini::Ini;
+
+    #[test]
+    fn read_ini_fails_due_to_capacity() {
+        let mut heap: TFixedIHeapClass<TeamTypeClass> = TFixedIHeapClass::with_capacity(1);
+
+        let filename = env!("CARGO_MANIFEST_DIR").to_owned() + "/tests/testdata/SCG62EA.INI";
+        let ini = Ini::load_from_file(filename).unwrap();
+        let result = heap.try_read_ini(&ini);
+        assert_eq!(
+            result.err(),
+            Some(FromIniError::ReadTeamEntriesError(
+                ReadTeamEntriesError::Insert(InsertError::ReachedCapacity(19, 1))
+            ))
+        );
+    }
+
+    #[test]
+    fn read_ini_works() {
+        let mut heap: TFixedIHeapClass<TeamTypeClass> = TFixedIHeapClass::with_capacity(19);
+        let filename = env!("CARGO_MANIFEST_DIR").to_owned() + "/tests/testdata/SCG62EA.INI";
+        let ini = Ini::load_from_file(filename).unwrap();
+        let result = heap.try_read_ini(&ini).unwrap();
+        assert_eq!(result.len(), 19);
+    }
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -99,6 +99,7 @@ impl ThemeControl {
 
 pub type TransitTheme = Option<ThemeType>;
 
+#[derive(Default)]
 pub struct ThemeClass {}
 
 impl ThemeClass {


### PR DESCRIPTION
As in C++ code TeamTypeClasses may only be instantiated inside instances of TFixedIHeapClass.

Returns borrowed mutable subslice of allocated TeamTypeClass instances.